### PR TITLE
fix: Ensure that Credo checks work

### DIFF
--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: block
           disable-sudo: true

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           disable-sudo: true
           egress-policy: block

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -61,7 +61,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: erlef/setup-beam@e6d7c94229049569db56a7ad5a540c051a010af9 # v1.20.4
+      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         id: install
         with:
           otp-version: ${{ matrix.otp }}

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           disable-sudo: true
           egress-policy: block
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           disable-sudo: true
           egress-policy: block
@@ -61,7 +61,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: reviewdog/action-actionlint@0d952c597ef8459f634d7145b0b044a9699e5e43 # v1.71.0
+      - uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0
 
   credo:
     if: ${{ github.event.action != 'closed' }}
@@ -74,7 +74,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -90,7 +90,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: erlef/setup-beam@e6d7c94229049569db56a7ad5a540c051a010af9 # v1.20.4
+      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         id: install
         with:
           otp-version: '27'

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           disable-sudo: true
           egress-policy: block

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Enviable Changelog
 
-## 2.2.0 / 2026-MM-DD
+## 2.2.1 / 2026-04-11
+
+- Fixed an issue where the Enviable [Credo][credo] checks only work if you have
+  Credo 1.7.14 or higher, but the requirement says any Credo version 1.0 or
+  higher. This has been resolved by restricting the minimum version of Credo
+  required. For most users, this should be sufficient. Please file an
+  [issue][issues] if you cannot upgrade to this version of Credo.
+
+## 2.2.0 / 2026-01-25
 
 - Added support for [`Duration`][duration] values. This includes updating the
   support for `timeout` conversions to parse ISO 8601 duration representations.
@@ -154,6 +162,7 @@
 [mise]: https://mise.jdx.dev
 [nimble_parsec]: https://hexdocs.pm/nimble_parsec/NimbleParsec.html
 [nvir]: https://hexdocs.pm/nvir/readme.html
+[issues]: https://github.com/halostatue/enviable/issues
 [timeout]: `m:Enviable#fetch_env_as_timeout/1-timeout-values`
 [to_timeout]: https://hexdocs.pm/elixir/Kernel.html#to_timeout/1
 [urules]: https://github.com/ash-project/usage_rules

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Documentation is found on [HexDocs][docs].
 [envious]: https://github.com/jax-ex/envious
 [hexpm]: https://hex.pm/package/enviable
 [jetenv]: https://hexdocs.pm/jetenv/readme.html
-[licence]: https://github.com/halostatue/prosody/blob/main/LICENCE.md
+[licence]: https://github.com/halostatue/enviable/blob/main/LICENCE.md
 [nvir]: https://hexdocs.pm/nvir/readme.html
 [semver]: https://semver.org/
 [shield-coveralls]: https://img.shields.io/coverallsCoverage/github/halostatue/enviable?style=for-the-badge

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Enviable.MixProject do
 
   @app :enviable
   @project_url "https://github.com/halostatue/enviable"
-  @version "2.2.0"
+  @version "2.2.1"
 
   def project do
     [
@@ -62,7 +62,7 @@ defmodule Enviable.MixProject do
       {:nimble_parsec, "~> 1.4"},
       {:decimal, "~> 2.0", optional: true},
       {:jason, "~> 1.0", optional: true},
-      {:credo, "~> 1.0", optional: true, runtime: false},
+      {:credo, "~> 1.7 and >= 1.7.14", optional: true, runtime: false},
       {:castore, "~> 1.0", only: [:dev, :test]},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:excoveralls, "~> 0.18", only: [:test]},


### PR DESCRIPTION
Fixed an issue where the Enviable Credo checks only work if you have Credo 1.7.14 or higher, but the requirement says any Credo version 1.0 or higher. This has been resolved by restricting the minimum version of Credo required. For most users, this should be sufficient. Please file an issue if you cannot upgrade to this version of Credo.